### PR TITLE
Death report fixups

### DIFF
--- a/src/FaultHandler/DeathReport.h
+++ b/src/FaultHandler/DeathReport.h
@@ -34,6 +34,20 @@
 #define DEATH_REPORT_STACK_TRACE_SIZE 128
 
 /**
+ * @brief   BSW DeathReport may contain additional data after the stack trace,
+ *          e.g. self-tests status, which is not used by the TASTE applications.
+ *          However, it's necessary to calculate the checksum over this data
+ *          even if it's unused, to match the BSW behavior - otherwise the death
+ *          report will always fail checksum check on BSW side and will never
+ *          be recognized as valid, making it impossible for BSW to detect ASW
+ *          crash. The amount of bytes is not constant, as it depends on the BSW
+ *          tailoring, so it's left for the user to define that in Makefile.
+*/
+#ifndef DEATH_REPORT_RESERVED_BYTES
+#define DEATH_REPORT_RESERVED_BYTES 0
+#endif
+
+/**
  * @brief Structure representing DeathReport.
  */
 typedef struct __attribute__((packed, aligned(sizeof(uint32_t)))) {
@@ -83,6 +97,9 @@ typedef struct __attribute__((packed, aligned(sizeof(uint32_t)))) {
 	uint32_t stack_trace_pointer; // Saved stack trace pointer.
 	uint32_t stack_trace_length; // Saved stack trace length.
 	uint32_t stack_trace[DEATH_REPORT_STACK_TRACE_SIZE];
+#if DEATH_REPORT_RESERVED_BYTES > 0
+	uint8_t _reserved[DEATH_REPORT_RESERVED_BYTES]
+#endif
 } DeathReportWriter_DeathReport;
 
 #endif

--- a/src/FaultHandler/DeathReport.h
+++ b/src/FaultHandler/DeathReport.h
@@ -44,7 +44,8 @@
  *          tailoring, so it's left for the user to define that in Makefile.
 */
 #ifndef DEATH_REPORT_RESERVED_BYTES
-#define DEATH_REPORT_RESERVED_BYTES 0
+// Default value is set for default set of self-tests on SAMV71 build
+#define DEATH_REPORT_RESERVED_BYTES 35
 #endif
 
 /**

--- a/src/FaultHandler/DeathReportWriter.c
+++ b/src/FaultHandler/DeathReportWriter.c
@@ -29,7 +29,7 @@ extern const uint32_t bsp_section_rtemsstack_end;
 extern DeathReportWriter_DeathReport DEATH_REPORT_BEGIN;
 
 static void
-save_stack(volatile DeathReportWriter_DeathReport *const death_report)
+save_stack(DeathReportWriter_DeathReport *const death_report)
 {
 	/* Calculate available stack space in bytes. DEATH_REPORT_STACK_TRACE_SIZE is
 	 * in words, so max capacity is DEATH_REPORT_STACK_TRACE_SIZE * sizeof(uint32_t)
@@ -87,8 +87,8 @@ bool DeathReportWriter_Init()
 
 bool DeathReportWriter_GenerateDeathReport()
 {
-	volatile DeathReportWriter_DeathReport *const death_report =
-		(volatile DeathReportWriter_DeathReport *)&DEATH_REPORT_BEGIN;
+	DeathReportWriter_DeathReport *const death_report =
+		(DeathReportWriter_DeathReport *)&DEATH_REPORT_BEGIN;
 
 	save_stack(death_report);
 

--- a/src/FaultHandler/DeathReportWriter.c
+++ b/src/FaultHandler/DeathReportWriter.c
@@ -19,31 +19,38 @@
 
 #include <DeathReportWriter.h>
 #include <DeathReport.h>
+#include <string.h>
 
 #define CRC_INITIAL_VALUE 0xFFFF
 #define CRC_POLYNOMIAL 0x1021
 #define CRC_MOST_SYGNIFICANT_BIT 0x8000
 
 extern const uint32_t bsp_section_rtemsstack_end;
-extern const uint32_t DEATH_REPORT_BEGIN;
+extern DeathReportWriter_DeathReport DEATH_REPORT_BEGIN;
 
-static void save_stack(DeathReportWriter_DeathReport *const death_report)
+static void
+save_stack(volatile DeathReportWriter_DeathReport *const death_report)
 {
-	if ((bsp_section_rtemsstack_end - death_report->stack_trace_pointer) <
-	    DEATH_REPORT_STACK_TRACE_SIZE) {
-		death_report->stack_trace_length =
-			bsp_section_rtemsstack_end -
-			death_report->stack_trace_pointer;
+	/* Calculate available stack space in bytes. DEATH_REPORT_STACK_TRACE_SIZE is
+	 * in words, so max capacity is DEATH_REPORT_STACK_TRACE_SIZE * sizeof(uint32_t)
+	 * bytes. */
+	const uint32_t available_bytes =
+		bsp_section_rtemsstack_end - death_report->stack_trace_pointer;
+	const uint32_t max_bytes =
+		DEATH_REPORT_STACK_TRACE_SIZE * sizeof(uint32_t);
+
+	if (available_bytes < max_bytes) {
+		death_report->stack_trace_length = available_bytes;
 	} else {
-		death_report->stack_trace_length =
-			DEATH_REPORT_STACK_TRACE_SIZE;
+		death_report->stack_trace_length = max_bytes;
 	}
 
-	const uint32_t *const stack =
-		(const uint32_t *)death_report->stack_trace_pointer;
-	for (uint32_t i = 0; i < death_report->stack_trace_length; i++) {
-		death_report->stack_trace[i] = stack[i];
-	}
+	/* Use memcpy to safely copy stack contents, avoiding direct pointer
+	 * cast/dereference of unvalidated stack_trace_pointer value from exception
+	 * context. */
+	memcpy((void *)death_report->stack_trace,
+	       (const void *)death_report->stack_trace_pointer,
+	       death_report->stack_trace_length);
 }
 
 static uint16_t calculate_crc(const uint8_t *const data, const size_t length)
@@ -80,15 +87,16 @@ bool DeathReportWriter_Init()
 
 bool DeathReportWriter_GenerateDeathReport()
 {
-	DeathReportWriter_DeathReport *const death_report =
-		(DeathReportWriter_DeathReport *const)&DEATH_REPORT_BEGIN;
+	volatile DeathReportWriter_DeathReport *const death_report =
+		(volatile DeathReportWriter_DeathReport *)&DEATH_REPORT_BEGIN;
 
 	save_stack(death_report);
 
 	death_report->padding = 0u;
 	death_report->was_seen = false;
-	death_report->checksum = calculate_report_crc(
-		death_report, sizeof(DeathReportWriter_DeathReport));
+	death_report->checksum =
+		calculate_report_crc((const void *)death_report,
+				     sizeof(DeathReportWriter_DeathReport));
 
 	return true;
 }

--- a/src/FaultHandler/DeathReportWriter.c
+++ b/src/FaultHandler/DeathReportWriter.c
@@ -19,7 +19,6 @@
 
 #include <DeathReportWriter.h>
 #include <DeathReport.h>
-#include <string.h>
 
 #define CRC_INITIAL_VALUE 0xFFFF
 #define CRC_POLYNOMIAL 0x1021
@@ -45,12 +44,12 @@ save_stack(DeathReportWriter_DeathReport *const death_report)
 		death_report->stack_trace_length = max_bytes;
 	}
 
-	/* Use memcpy to safely copy stack contents, avoiding direct pointer
-	 * cast/dereference of unvalidated stack_trace_pointer value from exception
-	 * context. */
-	memcpy((void *)death_report->stack_trace,
-	       (const void *)death_report->stack_trace_pointer,
-	       death_report->stack_trace_length);
+	uint8_t *const stack_trace_bytes = (uint8_t *)death_report->stack_trace;
+	const uint8_t *const stack_bytes =
+		(const uint8_t *)(uintptr_t)death_report->stack_trace_pointer;
+	for (uint32_t i = 0; i < death_report->stack_trace_length; i++) {
+		stack_trace_bytes[i] = stack_bytes[i];
+	}
 }
 
 static uint16_t calculate_crc(const uint8_t *const data, const size_t length)


### PR DESCRIPTION
This PR fixes an undefined behavior in death report code - removes type punning and replaces it with proper extern struct definition, which resolves the problem of CRC calculations being optimized away.

Additionally, this PR adds support for padding at the end of death report for BSW compatibility - otherwise BSW would never accept this death report as valid, as the checksum would be calculated over wrong memory area.
