### PR TITLE
Removed Scb_disableDCache calls from XDMAC driver

### DIFF
--- a/src/BootHelper/BootHelper.c
+++ b/src/BootHelper/BootHelper.c
@@ -24,6 +24,7 @@ enum Reset_Reason BootHelper_GetResetReason()
 {
 	const Rstc_ResetType reset_type = Rstc_getLastResetType();
 
+	// Map the hardware reset cause to the runtime's public reset reason enum.
 	switch (reset_type) {
 	case Rstc_ResetType_Powerup: {
 		return Reset_Reason_Powerup;

--- a/src/BootHelper/BootHelper.h
+++ b/src/BootHelper/BootHelper.h
@@ -41,6 +41,8 @@ enum Reset_Reason {
  * @brief               Returns information about reason of hardware reset
  *
  * @return              Enum representing possible reasons of hardware reset
+ *
+ * @satisfies MBEP-RT-FUN-310
  */
 enum Reset_Reason BootHelper_GetResetReason();
 

--- a/src/BrokerLock/BrokerLock.c
+++ b/src/BrokerLock/BrokerLock.c
@@ -27,6 +27,7 @@ extern rtems_id broker_Semaphore;
 
 void Broker_acquire_lock()
 {
+	// Serialize broker access through the shared RTEMS semaphore.
 	const rtems_status_code result = rtems_semaphore_obtain(
 		broker_Semaphore, RTEMS_WAIT, RTEMS_NO_TIMEOUT);
 	assert(result == RTEMS_SUCCESSFUL);
@@ -34,5 +35,6 @@ void Broker_acquire_lock()
 
 void Broker_release_lock()
 {
+	// Release the semaphore once the broker-critical section is done.
 	rtems_semaphore_release(broker_Semaphore);
 }

--- a/src/FaultHandler/CustomExceptionVector.c
+++ b/src/FaultHandler/CustomExceptionVector.c
@@ -28,6 +28,10 @@ extern const char _ISR_Stack_area_end[];
 
 void __attribute__((naked, aligned(8))) Fault_Handler();
 
+/** @brief Interrupt table to provide direct access for FaultHandler
+ *
+ * @satisfies MBEP-RT_FUN-330
+ */
 __attribute__((section(".vector"), aligned(VECTOR_TABLE_ALIGNMENT)))
 const Nvic_VectorTable exception_table = {
   // Route fatal exceptions to the custom fault handler and normal IRQs to RTEMS.

--- a/src/FaultHandler/CustomExceptionVector.c
+++ b/src/FaultHandler/CustomExceptionVector.c
@@ -30,6 +30,8 @@ void __attribute__((naked, aligned(8))) Fault_Handler();
 
 __attribute__((section(".vector"), aligned(VECTOR_TABLE_ALIGNMENT)))
 const Nvic_VectorTable exception_table = {
+  // Route fatal exceptions to the custom fault handler and normal IRQs to RTEMS.
+
   // configure stack pointer using linker symbols
   .initialStackPointer = (void*)_ISR_Stack_area_end,
 

--- a/src/FaultHandler/DeathReport.h
+++ b/src/FaultHandler/DeathReport.h
@@ -44,22 +44,24 @@
  *          tailoring, so it's left for the user to define that in Makefile.
 */
 #ifndef DEATH_REPORT_RESERVED_BYTES
-// Default value is set for default set of self-tests on SAMV71 build
+// Default value matches the default self-test layout for the SAMV71 build.
 #define DEATH_REPORT_RESERVED_BYTES 35
 #endif
 
 /**
  * @brief Structure representing DeathReport.
+ *
+ * The report layout is packed to match the boot software checksum format.
  */
 typedef struct __attribute__((packed, aligned(sizeof(uint32_t)))) {
 	uint16_t checksum; // Report checksum.
-	bool was_seen; // Death report was seen by BSW.
-	uint8_t padding; // Padding.
-	uint32_t exception_id; // Id of the called exception.
+	bool was_seen; // Set by the boot software after the report is consumed.
+	uint8_t padding; // Alignment padding.
+	uint32_t exception_id; // Faulting exception ID.
 
 	/**
-   * @brief Structure holding registers values.
-   */
+	 * @brief Structure holding register values captured at the fault point.
+	 */
 	struct __attribute__((packed)) {
 		uint32_t r0; // R0 register copy.
 		uint32_t r1; // R1 register copy.
@@ -86,8 +88,8 @@ typedef struct __attribute__((packed, aligned(sizeof(uint32_t)))) {
 	} registers; // Registers copy.
 
 	/**
-   * @brief Structure holding SCB registers.
-   */
+	 * @brief System Control Block status copied into the report.
+	 */
 	struct __attribute__((packed)) {
 		uint32_t cfsr; // Configurable Fault Status Register copy.
 		uint32_t hfsr; // HardFault Status Register copy.
@@ -97,6 +99,7 @@ typedef struct __attribute__((packed, aligned(sizeof(uint32_t)))) {
 
 	uint32_t stack_trace_pointer; // Saved stack trace pointer.
 	uint32_t stack_trace_length; // Saved stack trace length.
+	// Stack words are copied verbatim so post-mortem tooling can reconstruct the fault context.
 	uint32_t stack_trace[DEATH_REPORT_STACK_TRACE_SIZE];
 #if DEATH_REPORT_RESERVED_BYTES > 0
 	uint8_t _reserved[DEATH_REPORT_RESERVED_BYTES];

--- a/src/FaultHandler/DeathReportWriter.c
+++ b/src/FaultHandler/DeathReportWriter.c
@@ -27,10 +27,11 @@
 extern const uint32_t bsp_section_rtemsstack_end;
 extern DeathReportWriter_DeathReport DEATH_REPORT_BEGIN;
 
-static void
-save_stack(DeathReportWriter_DeathReport *const death_report)
+static void save_stack(DeathReportWriter_DeathReport *const death_report)
 {
-	/* Calculate available stack space in bytes. DEATH_REPORT_STACK_TRACE_SIZE is
+	/* Copy the active stack region into the report, capped to the report buffer.
+	 *
+	 * Calculate available stack space in bytes. DEATH_REPORT_STACK_TRACE_SIZE is
 	 * in words, so max capacity is DEATH_REPORT_STACK_TRACE_SIZE * sizeof(uint32_t)
 	 * bytes. */
 	const uint32_t available_bytes =
@@ -72,6 +73,7 @@ static uint16_t calculate_crc(const uint8_t *const data, const size_t length)
 static uint16_t calculate_report_crc(const void *const report,
 				     const size_t total_size)
 {
+	// Compute the checksum over the report payload, excluding the CRC field.
 	const uint8_t *const address_without_crc =
 		(const uint8_t *)report + sizeof(uint16_t);
 	const size_t size_without_crc = total_size - sizeof(uint16_t);
@@ -89,6 +91,7 @@ bool DeathReportWriter_GenerateDeathReport()
 	DeathReportWriter_DeathReport *const death_report =
 		(DeathReportWriter_DeathReport *)&DEATH_REPORT_BEGIN;
 
+	// Populate the shared death-report area before the fatal reset path runs.
 	save_stack(death_report);
 
 	death_report->padding = 0u;

--- a/src/FaultHandler/DeathReportWriter.h
+++ b/src/FaultHandler/DeathReportWriter.h
@@ -37,6 +37,17 @@
  */
 bool DeathReportWriter_Init(void);
 
+/**
+ * @brief                       Generates Death Report and saves it in configurable memory location.
+ *
+ *                              The location of saved Death Report is configured by providing symbol
+ *                              DEATH_REPORT_BEGIN by linker script.
+ *
+ * @return                      Bool indicating whether the initialization was
+ *                              successful
+ *
+ * @satisfies MBEP-RT-FUN-331, MBEP-RT-IF-110, MBEP-RT-IF-120
+ */
 bool DeathReportWriter_GenerateDeathReport();
 
 #endif

--- a/src/FaultHandler/FaultHandler.c
+++ b/src/FaultHandler/FaultHandler.c
@@ -30,6 +30,7 @@ extern const Nvic_VectorTable exception_table;
 
 void __attribute__((noreturn)) Fault_HandlerTail(void)
 {
+	// Write the fault report, flush caches, and force a system reset.
 	DeathReportWriter_GenerateDeathReport();
 
 	(void)Scb_cleanDCache();
@@ -184,6 +185,7 @@ bool FaultHandler_Init()
 	static volatile Scb_Registers *const scb =
 		(volatile Scb_Registers *)SCB_BASE_ADDRESS;
 
+	// Enable the fault paths that must be captured by the custom handler.
 	scb->shcsr = scb->shcsr | SCB_SHCSR_USGFAULTENA_MASK;
 	scb->ccr |= SCB_CCR_DIV_0_TRP_MASK;
 

--- a/src/FaultHandler/FaultHandler.h
+++ b/src/FaultHandler/FaultHandler.h
@@ -23,6 +23,8 @@
 /**
  * @file    FaultHandler.h
  * @brief   Header for FaultHandler
+ *
+ * @satisfies MBEP-RT-FUN-320
  */
 
 #include <stdbool.h>
@@ -34,6 +36,8 @@
  *
  * @return                      Bool indicating whether the initialization was
  *                              successful
+ *
+ * @satisfies MBEP-RT-FUN-330
  */
 bool FaultHandler_Init(void);
 

--- a/src/Hal/Hal.c
+++ b/src/Hal/Hal.c
@@ -134,6 +134,7 @@ void Hal_ResetWatchdog()
 
 void timer_irq_handler()
 {
+	// Count elapsed timer reloads and mark the snapshot as dirty for readers.
 	__atomic_fetch_add(&reloads_counter, 1u, __ATOMIC_RELAXED);
 	ConcurrentAccessFlag_set(&reloads_modified_flag);
 
@@ -143,6 +144,7 @@ void timer_irq_handler()
 
 static void Hal_InitTimer(void)
 {
+	// Configure the periodic timer that backs elapsed-time and sleep services.
 	reloads_counter = 0u;
 #if defined(N7S_TARGET_SAMV71Q21)
 	SamV71Core_EnablePeripheralClock(Pmc_PeripheralId_Tc0Ch0);
@@ -202,6 +204,7 @@ bool Hal_Init(void)
 
 uint64_t Hal_GetElapsedTimeInNs(void)
 {
+	// Read reload and timer state until a consistent snapshot is observed.
 	uint32_t reloads;
 	uint32_t ticks;
 
@@ -226,6 +229,7 @@ uint64_t Hal_GetElapsedTimeInNs(void)
 
 bool Hal_SleepNs(uint64_t time_ns)
 {
+	// Convert the requested duration to RTEMS ticks and sleep for that span.
 	const double sleep_tick_count =
 		time_ns * ((double)main_clock_frequency / NANOSECOND_IN_SECOND);
 

--- a/src/Hal/Hal.h
+++ b/src/Hal/Hal.h
@@ -45,7 +45,9 @@ bool Hal_Init(void);
  * @brief               Returns time elapsed from the initialization of the
  *                      runtime
  *
- * @return              Time elapsed from the initialization of the runtime
+ * @return              Time elapsed from the initialization of the runtime in nanoseconds
+ *
+ * @satisfies MBEP-RT-FUN-370, MBEP-RT-IF-310
  */
 uint64_t Hal_GetElapsedTimeInNs(void);
 

--- a/src/Monitor/Monitor.c
+++ b/src/Monitor/Monitor.c
@@ -85,6 +85,7 @@ handle_activation_log_cyclic_buffer(const enum interfaces_enum interface,
 static bool cpu_usage_visitor(Thread_Control *the_thread, void *arg)
 {
 	(void)arg;
+	// Refresh idle-thread CPU usage statistics from RTEMS accounting data.
 	float usage_percent;
 	uint32_t integer_val;
 	uint32_t float_val;
@@ -191,6 +192,7 @@ static bool thread_stack_usage_visitor(Thread_Control *the_thread, void *arg)
 
 bool Monitor_Init()
 {
+	// Reset monitoring baselines before runtime execution starts.
 	_Timestamp_Set_to_zero(&total_usage_time);
 	rtems_cpu_usage_reset();
 	_TOD_Get_uptime(&uptime_at_last_reset);

--- a/src/Monitor/Monitor.h
+++ b/src/Monitor/Monitor.h
@@ -114,6 +114,8 @@ bool Monitor_MonitoringTick(void);
  *                              interface, it is considered an output parameter
  *
  * @return                      Bool indicating whether the query about usage data was successful
+ *
+ * @satisfies                   MBEP-RT-FUN-630, MBEP-RT-FUN-640, MBEP-RT-FUN-650
  */
 bool Monitor_GetUsageData(const enum interfaces_enum interface,
 			  struct Monitor_InterfaceUsageData *const usage_data);
@@ -126,6 +128,8 @@ bool Monitor_GetUsageData(const enum interfaces_enum interface,
  *                              not used by any sporadic/cyclic interface
  *
  * @return                      Bool indicating whether the query about CPU usage data was successful
+ *
+ * @satisfies                   MBEP-RT-FUN-610
  */
 bool Monitor_GetIdleCPUUsageData(
 	struct Monitor_CPUUsageData *const cpu_usage_data);
@@ -136,6 +140,8 @@ bool Monitor_GetIdleCPUUsageData(
  * @param[in] interface         represents interface to obtain information about stack usage
  *
  * @return                      represents maximum stack usage in bytes if >= 0, and error otherwise.
+ *
+ * @satisfies                   MBEP-RT-FUN-620
  */
 int32_t Monitor_GetMaximumStackUsage(const enum interfaces_enum interface);
 
@@ -145,6 +151,8 @@ int32_t Monitor_GetMaximumStackUsage(const enum interfaces_enum interface);
  * @param[in] overflow_callback  pointer to function that implements message queue overflow callback
  *
  * @return                       indicates whether the set was successful.
+ *
+ * @satisfies                    MBEP-RT-FUN-350
  */
 bool Monitor_SetMessageQueueOverflowCallback(
 	Monitor_MessageQueueOverflow overflow_callback);
@@ -155,6 +163,8 @@ bool Monitor_SetMessageQueueOverflowCallback(
  * @param[in] interface          represents interface to obtain information about stack usage
  *
  * @return                       represents the number of queued items in interface queue if >= 0, and UINT32_MAX otherwise.
+ *
+ * @satisfies                    MBEP-RT-FUN-660
  */
 uint32_t Monitor_GetQueuedItemsCount(const enum interfaces_enum interface);
 
@@ -201,6 +211,8 @@ bool Monitor_IndicateInterfaceDeactivated(const enum interfaces_enum interface);
  * @param[out] out_size_of_activation_log            representing size of activation log
  *
  * @return                                           Bool indicating whether the query was successful
+ *
+ * @satisfies                                        MBEP-RT-FUN-670
  */
 bool Monitor_GetInterfaceActivationEntryLog(
 	struct Monitor_InterfaceActivationEntry **activation_log,

--- a/src/Monitor/Monitor.h
+++ b/src/Monitor/Monitor.h
@@ -36,10 +36,10 @@
 #include <stdlib.h>
 
 /**
- * @brief   Struct representing usage and benchmarking data for the given
- * interface
+ * @brief Aggregated execution-time statistics for one interface, in nanoseconds.
  */
 struct Monitor_InterfaceUsageData {
+	// Per-interface execution statistics are collected in nanoseconds.
 	enum interfaces_enum interface;
 	uint64_t maximum_execution_time;
 	uint64_t minimum_execution_time;
@@ -48,6 +48,8 @@ struct Monitor_InterfaceUsageData {
 
 /**
  * @brief   Struct representing cpu usage data
+ *
+ * CPU usage is tracked as a rolling min/max/average for the idle thread.
  */
 struct Monitor_CPUUsageData {
 	float maximum_cpu_usage;
@@ -56,7 +58,7 @@ struct Monitor_CPUUsageData {
 };
 
 /**
- * @brief   Struct representing two possible types of entry value
+ * @brief Kinds of entries stored in the activation log.
  */
 enum Monitor_EntryType {
 	Monitor_EntryType_activation = 0,
@@ -65,6 +67,8 @@ enum Monitor_EntryType {
 
 /**
  * @brief   Struct representing the interface activation entry
+ *
+ * Activation logs store the interface and edge type together with a timestamp.
  */
 struct Monitor_InterfaceActivationEntry {
 	enum interfaces_enum interface;
@@ -76,7 +80,7 @@ struct Monitor_InterfaceActivationEntry {
  * @brief                                       Typedef of callback indicating interface message queue overflow
  *
  * @param[in] interface                         represents interface which queue overflowed
- * @param[in] number_of_overflowed_messages     represents number of overflowed messages
+ * @param[in] number_of_overflowed_messages     represents number of overflowed (dropped) messages
  *
  */
 typedef void (*Monitor_MessageQueueOverflow)(
@@ -189,7 +193,7 @@ bool Monitor_IndicateInterfaceActivated(const enum interfaces_enum interface);
 bool Monitor_IndicateInterfaceDeactivated(const enum interfaces_enum interface);
 
 /**
- * @brief                                            Provides access to optional interface activation log.
+ * @brief                                            Provides access to the optional interface activation log.
  *
  * @param[out] activation_log                        pointer pointing to beginning of cyclic buffer holding
  *                                                   all activation entries

--- a/src/SamRH71Core/SamRH71Core.c
+++ b/src/SamRH71Core/SamRH71Core.c
@@ -46,6 +46,7 @@ static Mpu mpu;
 
 static uint64_t extract_main_oscillator_frequency(void)
 {
+	// Derive the base clock from the PMC main-clock source configuration.
 	Pmc_MainckConfig main_clock_config;
 	Pmc_getMainckConfig(&pmc, &main_clock_config);
 
@@ -84,6 +85,7 @@ static uint64_t extract_main_oscillator_frequency(void)
 static void apply_plla_config(Pmc_MasterckConfig *master_clock_config,
 			      uint64_t *mck_frequency)
 {
+	// Fold the PLLA settings into the clock frequency when PLLACK is selected.
 	if (master_clock_config->src == Pmc_MasterckSrc_Pllack) {
 		Pmc_PllConfig pll_config;
 		Pmc_getPllConfig(&pmc, &pll_config);
@@ -116,7 +118,7 @@ static void SamRH71Core_InitMatrix()
 		Matrix_Slave_Flexram1,
 		Matrix_Slave_Flexram2,
 	};
-    const uint32_t flexramSlavesCount = 3;
+	const uint32_t flexramSlavesCount = 3;
 	const Matrix_SlaveRegionProtectionConfig config = {
 		.isPrivilegedRegionUserWriteAllowed = true,
 		.isPrivilegedRegionUserReadAllowed = true,

--- a/src/SamRH71Core/SamRH71Core.h
+++ b/src/SamRH71Core/SamRH71Core.h
@@ -22,7 +22,7 @@
 
 /**
  * @file    SamRH71Core.h
- * @brief   Core functions for SamRH71 MCU.
+ * @brief   Core functions for the SAMRH71 MCU.
  */
 
 #include <stdint.h>
@@ -34,7 +34,7 @@
 #include <Utils/ErrorCode.h>
 
 /**
- * @brief               Initialize SAMRH71 Core module.
+ * @brief Initialize the SAMRH71 core helper module.
  */
 void SamRH71Core_Init(void);
 
@@ -47,56 +47,56 @@ void SamRH71Core_Init(void);
  * @param[in] handler_arg A parameter which shall be passed when calling handler.
   */
 void SamRH71Core_InterruptSubscribe(const rtems_vector_number vector,
-				   const char *info,
-				   rtems_interrupt_handler handler,
-				   void *handler_arg);
+				    const char *info,
+				    rtems_interrupt_handler handler,
+				    void *handler_arg);
 
 /**
- * @brief               Enable peripheral clock.
+ * @brief Enable the clock for a peripheral.
  *
- * @param[in] peripheralId clock identifier.
+ * @param[in] peripheralId Peripheral identifier.
  */
 void SamRH71Core_EnablePeripheralClock(const Pmc_PeripheralId peripheralId);
 
 /**
- * @brief               Get frequency of main clock.
+ * @brief Get the main clock frequency in hertz.
  *
- * @return              Main clock frequency in Hz.
+ * @return Main clock frequency in Hz.
  */
 uint64_t SamRH71Core_GetMainClockFrequency(void);
 
 /**
- * @brief               Generate new unique name for semaphore.
+ * @brief               Generate a new unique name for semaphore.
  *
- * @return              Unique name for semaphore.
+ * @return Unique RTEMS semaphore name.
  */
 rtems_name SamRH71Core_GenerateNewSemaphoreName(void);
 
 /**
- * @brief               Generate new unique name for task
+ * @brief               Generate a new unique name for task
  *
- * @return              Unique name for task.
+ * @return Unique RTEMS task name.
  */
 rtems_name SamRH71Core_GenerateNewTaskName(void);
 
 /**
- * @brief               Set configuration of PCKx.
+ * @brief Configure a programmable clock (PCKx) output.
  *
  * @param[in] id        PCK identifier.
- * @param[in] config    PCK configuration to set.
- * @param[in] timeout   Timeout of operation.
- * @param[out] errCode  ErrorCode pointer to write optional error code.
-
- * @return              Boolean value indicating operation success.
+ * @param[in] config    Configuration to apply.
+ * @param[in] timeout   Timeout for the operation.
+ * @param[out] errCode  Optional error code output.
+ *
+ * @return True on success.
  */
 bool SamRH71Core_SetPckConfig(const Pmc_PckId id,
-			     const Pmc_PckConfig *const config,
-			     const uint32_t timeout, ErrorCode *const errCode);
+			      const Pmc_PckConfig *const config,
+			      const uint32_t timeout, ErrorCode *const errCode);
 
 /**
- * @brief               Disable data cache for given memory region.
+ * @brief Disable the data cache for a memory region.
  *
- *                      This function is not thread-safe.
+ * This function is not thread-safe.
  *
  * @param[in] address   Region address.
  * @param[in] sizeExponent    Establishes size of the region as 2**(sizeExponent + 1)

--- a/src/SamRH71Core/SamRH71Core.h
+++ b/src/SamRH71Core/SamRH71Core.h
@@ -35,6 +35,8 @@
 
 /**
  * @brief Initialize the SAMRH71 core helper module.
+ *
+ * @satisfies MBEP-RT-FUN-710, MBEP-RT-FUN-720, MBEP-RT-PER-010
  */
 void SamRH71Core_Init(void);
 

--- a/src/SamV71Core/SamV71Core.c
+++ b/src/SamV71Core/SamV71Core.c
@@ -42,6 +42,7 @@ static Mpu mpu;
 
 static uint64_t extract_main_oscillator_frequency(void)
 {
+	// Derive the base clock from the PMC main-clock source configuration.
 	Pmc_MainckConfig main_clock_config;
 	Pmc_getMainckConfig(&pmc, &main_clock_config);
 
@@ -76,6 +77,7 @@ static uint64_t extract_main_oscillator_frequency(void)
 static void apply_plla_config(Pmc_MasterckConfig *master_clock_config,
 			      uint64_t *mck_frequency)
 {
+	// Fold the PLLA settings into the clock frequency when PLLACK is selected.
 	if (master_clock_config->src == Pmc_MasterckSrc_Pllack) {
 		Pmc_PllConfig pll_config;
 		Pmc_getPllConfig(&pmc, &pll_config);

--- a/src/SamV71Core/SamV71Core.c
+++ b/src/SamV71Core/SamV71Core.c
@@ -33,6 +33,9 @@
 #ifndef MAIN_CRYSTAL_OSCILLATOR_FREQUENCY
 #define MAIN_CRYSTAL_OSCILLATOR_FREQUENCY (12 * MEGA_HZ)
 #endif
+#ifndef EXTERNAL_CRYSTAL_OSCILLATOR_FREQUENCY
+#define EXTERNAL_CRYSTAL_OSCILLATOR_FREQUENCY (10 * MEGA_HZ)
+#endif
 
 extern void setCoreClockFrequency(uint64_t frequency);
 
@@ -48,6 +51,10 @@ static uint64_t extract_main_oscillator_frequency(void)
 
 	if (main_clock_config.src == Pmc_MainckSrc_XOsc) {
 		return MAIN_CRYSTAL_OSCILLATOR_FREQUENCY;
+	}
+
+	if (main_clock_config.src == Pmc_MainckSrc_XOscBypassed) {
+		return EXTERNAL_CRYSTAL_OSCILLATOR_FREQUENCY;
 	}
 
 	switch (main_clock_config.rcOscFreq) {

--- a/src/SamV71Core/SamV71Core.h
+++ b/src/SamV71Core/SamV71Core.h
@@ -22,7 +22,7 @@
 
 /**
  * @file    SamV71Core.h
- * @brief   Core functions for Samv71 MCU.
+ * @brief   Core functions for the SAMV71 MCU.
  */
 
 #include <stdint.h>
@@ -34,7 +34,7 @@
 #include <Utils/ErrorCode.h>
 
 /**
- * @brief               Initialize SAMV71 Core module.
+ * @brief Initialize the SAMV71 core helper module.
  */
 void SamV71Core_Init(void);
 
@@ -52,49 +52,49 @@ void SamV71Core_InterruptSubscribe(const rtems_vector_number vector,
 				   void *handler_arg);
 
 /**
- * @brief               Enable peripheral clock.
+ * @brief Enable the clock for a peripheral.
  *
- * @param[in] peripheralId clock identifier.
+ * @param[in] peripheralId Peripheral identifier.
  */
 void SamV71Core_EnablePeripheralClock(const Pmc_PeripheralId peripheralId);
 
 /**
- * @brief               Get frequency of main clock.
+ * @brief Get the main clock frequency in hertz.
  *
- * @return              Main clock frequency in Hz.
+ * @return Main clock frequency in Hz.
  */
 uint64_t SamV71Core_GetMainClockFrequency(void);
 
 /**
- * @brief               Generate new unique name for semaphore.
+ * @brief               Generate a new unique name for semaphore.
  *
- * @return              Unique name for semaphore.
+ * @return Unique RTEMS semaphore name.
  */
 rtems_name SamV71Core_GenerateNewSemaphoreName(void);
 
 /**
- * @brief               Generate new unique name for task
+ * @brief               Generate a new unique name for task
  *
- * @return              Unique name for task.
+ * @return Unique RTEMS task name.
  */
 rtems_name SamV71Core_GenerateNewTaskName(void);
 
 /**
- * @brief               Set configuration of PCKx.
+ * @brief Configure a programmable clock (PCKx) output.
  *
  * @param[in] id        PCK identifier.
- * @param[in] config    PCK configuration to set.
- * @param[in] timeout   Timeout of operation.
- * @param[out] errCode  ErrorCode pointer to write optional error code.
-
- * @return              Boolean value indicating operation success.
+ * @param[in] config    Configuration to apply.
+ * @param[in] timeout   Timeout for the operation.
+ * @param[out] errCode  Optional error code output.
+ *
+ * @return True on success.
  */
 bool SamV71Core_SetPckConfig(const Pmc_PckId id,
 			     const Pmc_PckConfig *const config,
 			     const uint32_t timeout, ErrorCode *const errCode);
 
 /**
- * @brief               Disable data cache for given memory region.
+ * @brief Disable the data cache for a memory region.
  *
  *                      This function is not thread-safe.
  *

--- a/src/SamV71Core/SamV71Core.h
+++ b/src/SamV71Core/SamV71Core.h
@@ -35,6 +35,8 @@
 
 /**
  * @brief Initialize the SAMV71 core helper module.
+ *
+ * @satisfies MBEP-RT-FUN-710, MBEP-RT-FUN-720
  */
 void SamV71Core_Init(void);
 

--- a/src/ThreadsCommon/ThreadsCommon.c
+++ b/src/ThreadsCommon/ThreadsCommon.c
@@ -56,6 +56,7 @@ static void schedule_next_tick(const uint32_t cyclic_request_data_index)
 	const rtems_id timer_id =
 		cyclic_request_data[cyclic_request_data_index].timer_id;
 
+	// Re-arm the cyclic request timer for the next dispatch instant.
 	cyclic_request_data[cyclic_request_data_index].next_wakeup_ticks +=
 		cyclic_request_data[cyclic_request_data_index].interval_ticks;
 	rtems_interval delta = cyclic_request_data[cyclic_request_data_index]
@@ -80,6 +81,7 @@ static void timer_callback(rtems_id timer_id, void *cyclic_request_data_index)
 static void update_execution_time_data(const uint32_t thread_id,
 				       const uint64_t thread_execution_time)
 {
+	// Fold the latest request duration into min/max/mean statistics.
 	if (thread_execution_time <
 	    threads_info[thread_id].min_thread_execution_time) {
 		threads_info[thread_id].min_thread_execution_time =
@@ -143,6 +145,7 @@ bool ThreadsCommon_ProcessRequest(const void *const request_data,
 {
 	call_function cast_user_function = (call_function)user_function;
 
+	// Measure one request execution and update per-thread monitoring data.
 	Monitor_IndicateInterfaceActivated(
 		(const enum interfaces_enum)thread_id);
 

--- a/src/Xdmac/xdma_hardware_interface.c
+++ b/src/Xdmac/xdma_hardware_interface.c
@@ -54,7 +54,9 @@
 /*----------------------------------------------------------------------------
  *        Local variables
  *----------------------------------------------------------------------------*/
-/** Array of DMA Channel definition for SAMv7 chip*/
+/** Array of DMA Channel definition for SAMv7 chip
+ *
+ * Map each supported peripheral to its XDMAC hardware handshake interface. */
 static const XdmaHardwareInterface xdmaHwIf[] = {
 	/* xdmac, peripheral,  T/R, HW interface number*/
 	{ 0, Pmc_PeripheralId_Hsmci, 0, 0 },

--- a/src/Xdmac/xdma_hardware_interface.h
+++ b/src/Xdmac/xdma_hardware_interface.h
@@ -38,12 +38,14 @@
  *        Types
  *----------------------------------------------------------------------------*/
 
-/** DMA hardware interface */
+/**
+ * @brief Maps one peripheral and transfer direction to an XDMAC handshake interface.
+ */
 typedef struct _XdmaHardwareInterface {
-	uint8_t bXdmac; /**< DMA Controller number */
-	uint32_t bPeriphID; /**< Peripheral ID */
-	uint8_t bTransfer; /**< Transfer type 0: Tx, 1 :Rx*/
-	uint8_t bIfID; /**< DMA Interface ID */
+	uint8_t bXdmac; /**< DMA controller number. */
+	uint32_t bPeriphID; /**< Peripheral identifier. */
+	uint8_t bTransfer; /**< Transfer type: 0 for Tx, 1 for Rx. */
+	uint8_t bIfID; /**< Hardware handshake interface identifier. */
 } XdmaHardwareInterface;
 
 /*----------------------------------------------------------------------------

--- a/src/Xdmac/xdmac.c
+++ b/src/Xdmac/xdmac.c
@@ -47,6 +47,10 @@
  *@{
  */
 
+/** \brief The helpers below provide direct register accessors and simple channel control
+ * wrappers for the XDMAC peripheral.
+ */
+
 /*----------------------------------------------------------------------------
  *        Exported functions
  *----------------------------------------------------------------------------*/

--- a/src/Xdmac/xdmad.c
+++ b/src/Xdmac/xdmad.c
@@ -70,7 +70,6 @@
 #include <Hal.h>
 
 #include <Pmc/Pmc.h>
-#include <Scb/Scb.h>
 
 #include <rtems.h>
 
@@ -371,9 +370,7 @@ void XDMAD_Handler(sXdmad *pDmad)
 					pCh->state = XDMAD_STATE_DONE;
 					bExec = 1;
 				}
-				Scb_disableDCache();
 			} else {
-				Scb_disableDCache();
 				/* Block end interrupt for LLI dma mode */
 				if (XDMAC_GetChannelIsr(pXdmac, _iChannel) &
 				    XDMAC_CIS_BIS) {
@@ -404,7 +401,6 @@ eXdmadRC XDMAD_IsTransferDone(sXdmad *pXdmad, uint32_t dwChannel)
 	if (iChannel >= pXdmad->numChannels)
 		return XDMAD_ERROR;
 
-	Scb_disableDCache();
 	state = pXdmad->XdmaChannels[iChannel].state;
 	if (state == XDMAD_STATE_ALLOCATED)
 		return XDMAD_OK;

--- a/src/Xdmac/xdmad.c
+++ b/src/Xdmac/xdmad.c
@@ -104,6 +104,7 @@ static uint32_t XDMAD_AllocateXdmacChannel(sXdmad *pXdmad, uint8_t bSrcID,
 					   uint8_t bDstID)
 {
 	uint32_t i;
+	// Reject unsupported peripheral-to-peripheral transfers before allocation.
 	/* Can't support peripheral to peripheral */
 	if (((bSrcID != XDMAD_TRANSFER_MEMORY) &&
 	     (bDstID != XDMAD_TRANSFER_MEMORY))) {
@@ -164,6 +165,7 @@ void XDMAD_Initialize(sXdmad *pXdmad, uint8_t bPollingMode)
 
 	assert(pXdmad);
 
+	// Initialize the shared XDMAC driver state once under the global lock.
 	const rtems_status_code obtainResult = rtems_semaphore_obtain(
 		xdmad_lock, RTEMS_WAIT, RTEMS_NO_TIMEOUT);
 	assert(obtainResult == RTEMS_SUCCESSFUL);
@@ -207,6 +209,7 @@ uint32_t XDMAD_AllocateChannel(sXdmad *pXdmad, uint8_t bSrcID, uint8_t bDstID)
 	uint32_t volatile timer = 0x7FF;
 	assert(xdmad_lock);
 
+	// Serialize channel allocation so concurrent users do not race the pool.
 	const rtems_status_code obtainResult =
 		rtems_semaphore_obtain(xdmad_lock, RTEMS_WAIT, timer);
 	if (obtainResult == RTEMS_SUCCESSFUL) {

--- a/src/Xdmac/xdmad.h
+++ b/src/Xdmac/xdmad.h
@@ -77,7 +77,7 @@
 /** \addtogroup dmad_structs DMA Driver Structs
         @{*/
 
-/** DMA status or return code */
+/** @brief DMA status or return code. */
 typedef enum _XdmadStatus {
 	XDMAD_OK = 0, /**< Operation is successful */
 	XDMAD_PARTIAL_DONE,
@@ -88,7 +88,7 @@ typedef enum _XdmadStatus {
 } eXdmadStatus,
 	eXdmadRC;
 
-/** DMA state for channel */
+/** @brief Lifecycle state of one DMA channel. */
 typedef enum _XdmadState {
 	XDMAD_STATE_FREE = 0, /**< Free channel */
 	XDMAD_STATE_ALLOCATED, /**< Allocated to some peripheral */
@@ -98,31 +98,31 @@ typedef enum _XdmadState {
 	XDMAD_STATE_HALTED, /**< DMA transfer stopped */
 } eXdmadState;
 
-/** DMA Programming state for channel */
+/** @brief Programming mode used for a DMA channel transfer. */
 typedef enum _XdmadProgState {
 	XDMAD_SINGLE = 0,
 	XDMAD_MULTI,
 	XDMAD_LLI,
 } eXdmadProgState;
 
-/** DMA transfer callback */
+/** @brief Callback invoked when a DMA transfer completes or changes state. */
 typedef void (*XdmadTransferCallback)(uint32_t iChannel, void *pArg);
 
-/** DMA driver channel */
+/** @brief Per-channel bookkeeping used by the XDMAC driver instance. */
 typedef struct _XdmadChannel {
-	XdmadTransferCallback fCallback; /**< Callback */
-	void *pArg; /**< Callback argument */
-	uint8_t bIrqOwner; /**< Uses DMA handler or external one */
-	uint8_t bSrcPeriphID; /**< HW ID for source */
-	uint8_t bDstPeriphID; /**< HW ID for destination */
-	uint8_t bSrcTxIfID; /**< DMA Tx Interface ID for source */
-	uint8_t bSrcRxIfID; /**< DMA Rx Interface ID for source */
-	uint8_t bDstTxIfID; /**< DMA Tx Interface ID for destination */
-	uint8_t bDstRxIfID; /**< DMA Rx Interface ID for destination */
-	volatile uint8_t state; /**< DMA channel state */
+	XdmadTransferCallback fCallback; /**< Completion callback. */
+	void *pArg; /**< Optional callback argument. */
+	uint8_t bIrqOwner; /**< True when the DMA handler owns the interrupt. */
+	uint8_t bSrcPeriphID; /**< Source peripheral ID. */
+	uint8_t bDstPeriphID; /**< Destination peripheral ID. */
+	uint8_t bSrcTxIfID; /**< Source Tx handshake interface ID. */
+	uint8_t bSrcRxIfID; /**< Source Rx handshake interface ID. */
+	uint8_t bDstTxIfID; /**< Destination Tx handshake interface ID. */
+	uint8_t bDstRxIfID; /**< Destination Rx handshake interface ID. */
+	volatile uint8_t state; /**< Channel state. */
 } sXdmadChannel;
 
-/** DMA driver instance */
+/** @brief DMA driver instance that owns the controller and its channels. */
 typedef struct _Xdmad {
 	Xdmac *pXdmacs;
 	sXdmadChannel XdmaChannels[XDMACCHID_NUMBER];
@@ -134,83 +134,87 @@ typedef struct _Xdmad {
 } sXdmad;
 
 typedef struct _XdmadCfg {
-	/** Microblock Control Member. */
+	/** Microblock control register value. */
 	uint32_t mbr_ubc;
-	/** Source Address Member. */
+	/** Source address register value. */
 	uint32_t mbr_sa;
-	/** Destination Address Member. */
+	/** Destination address register value. */
 	uint32_t mbr_da;
-	/** Configuration Register. */
+	/** Channel configuration register value. */
 	uint32_t mbr_cfg;
-	/** Block Control Member. */
+	/** Block control register value. */
 	uint32_t mbr_bc;
-	/** Data Stride Member. */
+	/** Data stride register value. */
 	uint32_t mbr_ds;
-	/** Source Microblock Stride Member. */
+	/** Source microblock stride register value. */
 	uint32_t mbr_sus;
-	/** Destination Microblock Stride Member. */
+	/** Destination microblock stride register value. */
 	uint32_t mbr_dus;
 } sXdmadCfg;
 
-/** \brief Structure for storing parameters for DMA view0 that can be
- * performed by the DMA Master transfer.*/
+/**
+ * @brief Linked-list descriptor format 0 used by XDMAC master transfers.
+ */
 typedef struct _LinkedListDescriptorView0 {
-	/** Next Descriptor Address number. */
+	/** Next descriptor address. */
 	uint32_t mbr_nda;
-	/** Microblock Control Member. */
+	/** Microblock control value. */
 	uint32_t mbr_ubc;
-	/** Transfer Address Member. */
+	/** Transfer address. */
 	uint32_t mbr_ta;
 } LinkedListDescriptorView0;
 
-/** \brief Structure for storing parameters for DMA view1 that can be
- * performed by the DMA Master transfer.*/
+/**
+ * @brief Linked-list descriptor format 1 used by XDMAC master transfers.
+ */
 typedef struct _LinkedListDescriptorView1 {
-	/** Next Descriptor Address number. */
+	/** Next descriptor address. */
 	uint32_t mbr_nda;
-	/** Microblock Control Member. */
+	/** Microblock control value. */
 	uint32_t mbr_ubc;
-	/** Source Address Member. */
+	/** Source address. */
 	uint32_t mbr_sa;
-	/** Destination Address Member. */
+	/** Destination address. */
 	uint32_t mbr_da;
 } LinkedListDescriptorView1;
 
-/** \brief Structure for storing parameters for DMA view2 that can be
- * performed by the DMA Master transfer.*/
+/**
+ * @brief Linked-list descriptor format 2 used by XDMAC master transfers.
+ */
 typedef struct _LinkedListDescriptorView2 {
-	/** Next Descriptor Address number. */
+	/** Next descriptor address. */
 	uint32_t mbr_nda;
-	/** Microblock Control Member. */
+	/** Microblock control value. */
 	uint32_t mbr_ubc;
-	/** Source Address Member. */
+	/** Source address. */
 	uint32_t mbr_sa;
-	/** Destination Address Member. */
+	/** Destination address. */
 	uint32_t mbr_da;
-	/** Configuration Register. */
+	/** Channel configuration register value. */
 	uint32_t mbr_cfg;
 } LinkedListDescriptorView2;
 
-/** \brief Structure for storing parameters for DMA view3 that can be
- * performed by the DMA Master transfer.*/
+/**
+ * @brief Linked-list descriptor format 3 used by XDMAC master transfers.
+ */
 typedef struct _LinkedListDescriptorView3 {
-	/** Next Descriptor Address number. */
+	/** Next descriptor address. */
 	uint32_t mbr_nda;
-	/** Microblock Control Member. */
+	/** Microblock control value. */
 	uint32_t mbr_ubc;
-	/** Source Address Member. */
+	/** Source address. */
 	uint32_t mbr_sa;
-	/** Destination Address Member. */
+	/** Destination address. */
 	uint32_t mbr_da;
-	/** Configuration Register. */
+	/** Channel configuration register value. */
 	uint32_t mbr_cfg;
-	/** Block Control Member. */
+	/** Block control value. */
 	uint32_t mbr_bc;
-	/** Data Stride Member. */
+	/** Data stride value. */
 	uint32_t mbr_ds;
-	/** Source Microblock Stride Member. */
+	/** Source microblock stride value. */
 	uint32_t mbr_sus;
-	/** Destination Microblock Stride Member. */
+	/** Destination microblock stride value. */
 	uint32_t mbr_dus;
 } LinkedListDescriptorView3;
 

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -45,6 +45,7 @@
 
 rtems_task Init(rtems_task_argument argument)
 {
+	// Minimal RTEMS entry point used to prove the runtime links and initializes.
 	Hal_Init();
 }
 


### PR DESCRIPTION
As a workaround for missing DCache flushing in UART driver, the XDMAC driver have been disabling it after the first successful transfer (which still caused an issue of first transfer processing invalid data). The issue in UART driver has been fixed correctly by adding proper DCache flushing in https://github.com/n7space/TASTE-SAMV71-RTEMS-Drivers/pull/24 - and this MR is removing the Scb_disableDCache calls from XDMAC driver, as it's not necessary now.